### PR TITLE
fix ROS test of wheel

### DIFF
--- a/arti_base_control/CMakeLists.txt
+++ b/arti_base_control/CMakeLists.txt
@@ -179,14 +179,18 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-catkin_add_gtest(${PROJECT_NAME}-test
-  test/test_wheel.cpp
-)
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
 
-if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+  # Wheel tests
+  add_rostest_gtest(
+    test_wheel
+    test/test_wheel.test
+    test/test_wheel.cpp
+  )
+  target_link_libraries(test_wheel
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
+
 endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/arti_base_control/package.xml
+++ b/arti_base_control/package.xml
@@ -51,6 +51,8 @@
   <exec_depend>tf</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
 
+  <test_depend>rostest</test_depend>
+
   <export>
   </export>
 </package>

--- a/arti_base_control/test/test_wheel.cpp
+++ b/arti_base_control/test/test_wheel.cpp
@@ -6,19 +6,30 @@
 #include <memory>
 #include <arti_base_control/steering.h>
 #include <arti_base_control/wheel.h>
+#include <arti_base_control/joint_state.h>
 
 TEST(WheelTest, SimpleFrontWheelTest)
 {
-  const arti_base_control::Wheel wheel(1.0, 0.0, 0.0, 0.5, std::make_shared<arti_base_control::IdealAckermannSteering>(0.0));
-  EXPECT_DOUBLE_EQ(2.0, wheel.computeWheelVelocity(1.0, 0.0, 0.0, 0.0));
-  EXPECT_DOUBLE_EQ(2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(1.0, 1.0, 0.0, 0.0));
-  EXPECT_DOUBLE_EQ(2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(1.0, -1.0, 0.0, 0.0));
-  EXPECT_DOUBLE_EQ(-2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(-1.0, 1.0, 0.0, 0.0));
-  EXPECT_DOUBLE_EQ(-2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(-1.0, -1.0, 0.0, 0.0));
+  const ros::NodeHandle steering_nh("steering");
+  auto ideal_ackermann_steering = std::make_shared<arti_base_control::IdealAckermannSteering>(steering_nh);
+
+  const arti_base_control::Wheel wheel(1.0, 0.0, 0.0, 0.5);
+
+  arti_base_control::JointState expected_steering_state;
+  expected_steering_state.position = 0.0;
+  expected_steering_state.velocity = 0.0;
+  const arti_base_control::JointState wheel_steering_state = ideal_ackermann_steering->computeWheelSteeringState(wheel, expected_steering_state);
+
+  EXPECT_DOUBLE_EQ(2.0, wheel.computeWheelVelocity(1.0, 0.0, wheel_steering_state));
+  EXPECT_DOUBLE_EQ(2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(1.0, 1.0, wheel_steering_state));
+  EXPECT_DOUBLE_EQ(2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(1.0, -1.0, wheel_steering_state));
+  EXPECT_DOUBLE_EQ(-2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(-1.0, 1.0, wheel_steering_state));
+  EXPECT_DOUBLE_EQ(-2.0 * std::sqrt(2.0), wheel.computeWheelVelocity(-1.0, -1.0, wheel_steering_state));
 }
 
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
+   ros::init(argc, argv, "steering_tester");
   return RUN_ALL_TESTS();
 }

--- a/arti_base_control/test/test_wheel.test
+++ b/arti_base_control/test/test_wheel.test
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>	
+<launch>	
+  <test test-name="test_wheel" pkg="arti_base_control" type="test_wheel" />	
+</launch>


### PR DESCRIPTION
fix ROS test of wheel (rewrite to be able to compile again and wrap into rostest such the test can run without any externally started roscore)